### PR TITLE
Fix it generates broken hyperlinks when calling execute function multiple times

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,10 @@ exports.executeAsync = function(config, callBack){
 }
 
 exports.execute = function(config){
+    sheetHyperlinksBack = '</x:hyperlinks>';
+    hyperlinksCount = 0;
+    sheetRelationshipsBack = '</Relationships>';
+
 	var cols = config.cols,
 		data = config.rows;
 	


### PR DESCRIPTION
- These global variables are updated in addHyperlinkCol
- Since execute function is synchronous, this should work although this patch is extremely ad-hoc